### PR TITLE
add [-Q . ""] to problem set _CoqProject files

### DIFF
--- a/pset01_ProgramAnalysis/_CoqProject
+++ b/pset01_ProgramAnalysis/_CoqProject
@@ -1,3 +1,4 @@
+-Q . ""
 -R ../frap Frap
 Pset1Sig.v
 Pset1.v

--- a/pset02_BinomialCoefficients/_CoqProject
+++ b/pset02_BinomialCoefficients/_CoqProject
@@ -1,1 +1,2 @@
+-Q . ""
 -Q ../frap Frap

--- a/pset03_ContainersAndHOFs/_CoqProject
+++ b/pset03_ContainersAndHOFs/_CoqProject
@@ -1,1 +1,2 @@
+-Q . ""
 -Q ../frap Frap

--- a/pset04_BSTs/_CoqProject
+++ b/pset04_BSTs/_CoqProject
@@ -1,3 +1,4 @@
+-Q . ""
 -R ../frap Frap
 Pset4Sig.v
 Pset4.v

--- a/pset05_BigStepVsInterpreter/_CoqProject
+++ b/pset05_BigStepVsInterpreter/_CoqProject
@@ -1,1 +1,2 @@
+-Q . ""
 -Q ../frap Frap


### PR DESCRIPTION
This ensures the directories are on the implicit LoadPath, so that
"Require Import PsetNSig" works okay.

This is useful for coqide users, because coqide (at least v8.11.0)
adds its current working directory to the implicit LoadPath, unlike
Proof General which always adds the directory where the file is
contained.