### PR TITLE
Fix make in pset08

### DIFF
--- a/pset08_HoareLogic/Makefile
+++ b/pset08_HoareLogic/Makefile
@@ -1,6 +1,6 @@
 .PHONY: coq clean
 
-COQC=coqc -q -R ../../frap Frap
+COQC=coqc -q -R ../frap Frap
 
 coq:
 	$(COQC) Pset8.v

--- a/pset08_HoareLogic/_CoqProject
+++ b/pset08_HoareLogic/_CoqProject
@@ -1,2 +1,2 @@
--R ../../frap Frap
+-R ../frap Frap
 Pset8.v


### PR DESCRIPTION
Otherwise it fails as follows:

```
$ make
coqc -q -R ../../frap Frap Pset8.v
While loading initial state:
Warning: Cannot open ../../frap [cannot-open-path,filesystem]
File "./Pset8.v", line 3, characters 15-19:
Error: Unable to locate library Frap.

make: *** [Makefile:6: coq] Error 1
```